### PR TITLE
Updating error code messages for uniformity

### DIFF
--- a/src/lib/errors/index.js
+++ b/src/lib/errors/index.js
@@ -23,11 +23,11 @@ const util = require('util');
  */
 const MojaloopApiErrorCodes = {
     //Generic communication errors
-    COMMUNICATION_ERROR:              { code: '1000', message: 'Server error' },
+    COMMUNICATION_ERROR:              { code: '1000', message: 'Communication error' },
     DESTINATION_COMMUNICATION_ERROR:  { code: '1001', message: 'Destination communication error' },
 
     //Generic server errors
-    SERVER_ERROR:                     { code: '2000', message: 'Server error' },
+    SERVER_ERROR:                     { code: '2000', message: 'Generic server error' },
     INTERNAL_SERVER_ERROR:            { code: '2001', message: 'Internal server error' },
     NOT_IMPLEMENTED:                  { code: '2002', message: 'Not implemented' , httpStatusCode: 501},
     SERVICE_CURRENTLY_UNAVAILABLE:    { code: '2003', message: 'Service currently unavailable', httpStatusCode: 503 },
@@ -35,24 +35,24 @@ const MojaloopApiErrorCodes = {
     SERVER_BUSY:                      { code: '2005', message: 'Server busy' },
 
     //Generic client errors
-    CLIENT_ERROR:                     { code: '3000', message: 'Client error', httpStatusCode: 400 },
-    UNACCEPTABLE_VERSION:             { code: '3001', message: 'Unacceptable version', httpStatusCode: 406 },
+    CLIENT_ERROR:                     { code: '3000', message: 'Generic client error', httpStatusCode: 400 },
+    UNACCEPTABLE_VERSION:             { code: '3001', message: 'Unacceptable version requested', httpStatusCode: 406 },
     UNKNOWN_URI:                      { code: '3002', message: 'Unknown URI', httpStatusCode: 404 },
-    ADD_PARTY_INFO_ERROR:             { code: '3003', message: 'Error updating or adding party information' },
+    ADD_PARTY_INFO_ERROR:             { code: '3003', message: 'Add Party information error' },
 
     //Client validation errors
-    VALIDATION_ERROR:                 { code: '3100', message: 'Validation error', httpStatusCode: 400 },
+    VALIDATION_ERROR:                 { code: '3100', message: 'Generic validation error', httpStatusCode: 400 },
     MALFORMED_SYNTAX:                 { code: '3101', message: 'Malformed syntax', httpStatusCode: 400 },
     MISSING_ELEMENT:                  { code: '3102', message: 'Missing mandatory element', httpStatusCode: 400 },
     TOO_MANY_ELEMENTS:                { code: '3103', message: 'Too many elements', httpStatusCode: 400 },
-    TOO_LARGE_PAYLOAD:                { code: '3104', message: 'Payload too large', httpStatusCode: 400 },
+    TOO_LARGE_PAYLOAD:                { code: '3104', message: 'Too large payload', httpStatusCode: 400 },
     INVALID_SIGNATURE:                { code: '3105', message: 'Invalid signature', httpStatusCode: 400 },
     MODIFIED_REQUEST:                 { code: '3106', message: 'Modified request', httpStatusCode: 400 },
-    MISSING_MANDATORY_EXTENSION:      { code: '3107', message: 'Missing mandatory extension', httpStatusCode: 400 },
+    MISSING_MANDATORY_EXTENSION:      { code: '3107', message: 'Missing mandatory extension parameter', httpStatusCode: 400 },
 
     //identifier errors
-    ID_NOT_FOUND:                     { code: '3200', message: 'ID not found' },
-    DESTINATION_FSP_ERROR:            { code: '3201', message: 'Destination FSP does not exist or cannot be found' },
+    ID_NOT_FOUND:                     { code: '3200', message: 'Generic ID not found' },
+    DESTINATION_FSP_ERROR:            { code: '3201', message: 'Destination FSP Error' },
     PAYER_FSP_ID_NOT_FOUND:           { code: '3202', message: 'Payer FSP ID not found' },
     PAYEE_FSP_ID_NOT_FOUND:           { code: '3203', message: 'Payee FSP ID not found' },
     PARTY_NOT_FOUND:                  { code: '3204', message: 'Party not found' },
@@ -64,35 +64,35 @@ const MojaloopApiErrorCodes = {
     BULK_TRANSFER_ID_NOT_FOUND:       { code: '3210', message: 'Bulk transfer ID not found' },
 
     //expired errors
-    EXPIRED_ERROR:                    { code: '3300', message: 'Entity expired' },
+    EXPIRED_ERROR:                    { code: '3300', message: 'Generic expired error' },
     TXN_REQUEST_EXPIRED:              { code: '3301', message: 'Transaction request expired' },
     QUOTE_EXPIRED:                    { code: '3302', message: 'Quote expired' },
     TRANSFER_EXPIRED:                 { code: '3303', message: 'Transfer expired' },
 
     //payer errors
-    PAYER_ERROR:                      { code: '4000', message: 'Error related to the Payer or Payer FSP' },
+    PAYER_ERROR:                      { code: '4000', message: 'Generic Payer error' },
     PAYER_FSP_INSUFFICIENT_LIQUIDITY: { code: '4001', message: 'Payer FSP insufficient liquidity' },
-    PAYER_REJECTION:                  { code: '4100', message: 'Payer or Payer FSP rejected the request' },
-    PAYER_REJECTED_TXN_REQUEST:       { code: '4101', message: 'Payer rejected the transaction request' },
-    PAYER_FSP_UNSUPPORTED_TXN_TYPE:   { code: '4102', message: 'Payer FSP does not support or rejected the transaction type' },
-    PAYER_UNSUPPORTED_CURRENCY:       { code: '4103', message: 'Payer does not have an account which supports the requested currency' },
-    PAYER_LIMIT_ERROR:                { code: '4200', message: 'Payer limit exceeded' },
-    PAYER_PERMISSION_ERROR:           { code: '4300', message: 'Payer or Payer FSP insufficient permissions' },
-    PAYER_BLOCKED_ERROR:              { code: '4400', message: 'Payer blocked' },
+    PAYER_REJECTION:                  { code: '4100', message: 'Generic Payer rejection' },
+    PAYER_REJECTED_TXN_REQUEST:       { code: '4101', message: 'Payer rejected transaction request' },
+    PAYER_FSP_UNSUPPORTED_TXN_TYPE:   { code: '4102', message: 'Payer FSP unsupported transaction type' },
+    PAYER_UNSUPPORTED_CURRENCY:       { code: '4103', message: 'Payer unsupported currency' },
+    PAYER_LIMIT_ERROR:                { code: '4200', message: 'Payer limit error' },
+    PAYER_PERMISSION_ERROR:           { code: '4300', message: 'Payer permission error' },
+    PAYER_BLOCKED_ERROR:              { code: '4400', message: 'Generic Payer blocked error' },
 
     //payee errors
-    PAYEE_ERROR:                      { code: '5000', message: 'Error related to the payee or payee FSP' },
+    PAYEE_ERROR:                      { code: '5000', message: 'Generic Payee error' },
     PAYEE_FSP_INSUFFICIENT_LIQUIDITY: { code: '5001', message: 'Payee FSP insufficient liquidity' },
-    PAYEE_REJECTION:                  { code: '5100', message: 'Payee or Payee FSP rejected the request.' },
+    PAYEE_REJECTION:                  { code: '5100', message: 'Generic Payee rejection' },
     PAYEE_REJECTED_QUOTE:             { code: '5101', message: 'Payee rejected quote' },
-    PAYEE_FSP_UNSUPPORTED_TXN_TYPE:   { code: '5102', message: 'Payee FSP does not support or rejected the transaction type' },
+    PAYEE_FSP_UNSUPPORTED_TXN_TYPE:   { code: '5102', message: 'Payee FSP unsupported transaction type' },
     PAYEE_FSP_REJECTED_QUOTE:         { code: '5103', message: 'Payee FSP rejected quote' },
-    PAYEE_REJECTED_TXN:               { code: '5104', message: 'Payee rejected the transaction' },
-    PAYEE_FSP_REJECTED_TXN:           { code: '5105', message: 'Payee FSP rejected the transaction.' },
-    PAYEE_UNSUPPORTED_CURRENCY:       { code: '5106', message: 'Payee does not have an account which supports the requested currency.' },
-    PAYEE_LIMIT_ERROR:                { code: '5200', message: 'Payee limit exceeded' },
-    PAYEE_PERMISSION_ERROR:           { code: '5300', message: 'Payee or Payee FSP insufficient permissions' },
-    GENERIC_PAYEE_BLOCKED_ERROR:      { code: '5400', message: 'Payee blocked' }
+    PAYEE_REJECTED_TXN:               { code: '5104', message: 'Payee rejected transaction' },
+    PAYEE_FSP_REJECTED_TXN:           { code: '5105', message: 'Payee FSP rejected transaction' },
+    PAYEE_UNSUPPORTED_CURRENCY:       { code: '5106', message: 'Payee unsupported currency' },
+    PAYEE_LIMIT_ERROR:                { code: '5200', message: 'Payee limit error' },
+    PAYEE_PERMISSION_ERROR:           { code: '5300', message: 'Payee permission error' },
+    GENERIC_PAYEE_BLOCKED_ERROR:      { code: '5400', message: 'Generic Payee blocked error' }
 };
 
 


### PR DESCRIPTION
- Updates to reflect the exact text from the specification v1.0.
- Also in some places, the text from the 'description' column from the spec (Section 7.6 in v1.0) is used and in most places, the text from the 'Name' column. Updating this to reflect text from the 'Name' column for every error for uniformity.
- Related issues mojaloop/project/issues/917, mojaloop/project/issues/900, etc.