### PR TITLE
Make sure that body is a String before calling request

### DIFF
--- a/src/lib/mojaloop-requests/mojaloopRequests.js
+++ b/src/lib/mojaloop-requests/mojaloopRequests.js
@@ -24,8 +24,6 @@ const throwOrJson = common.throwOrJson;
 const JwsSigner = require('../jws').signer;
 const WSO2Auth = require('./wso2auth');
 
-const bodyStringifier = require('./toString');
-
 /**
  * A class for making outbound requests with mutually authenticated TLS and JWS signing
  */
@@ -278,7 +276,7 @@ class MojaloopRequests {
             this.jwsSigner.sign(reqOpts);
         }
 
-        reqOpts.body = bodyStringifier(reqOpts.body);
+        reqOpts.body = this._bodyStringifier(reqOpts.body);
 
         try {
             this.logger.log(`Executing HTTP PUT: ${util.inspect(reqOpts)}`);
@@ -306,7 +304,7 @@ class MojaloopRequests {
             this.jwsSigner.sign(reqOpts);
         }
 
-        reqOpts.body = bodyStringifier(reqOpts.body);
+        reqOpts.body = this._bodyStringifier(reqOpts.body);
 
         try {
             this.logger.log(`Executing HTTP POST: ${util.inspect(reqOpts)}`);
@@ -317,8 +315,18 @@ class MojaloopRequests {
             throw e;
         }
     }
+
+    _bodyStringifier (obj) {
+        if (typeof obj === 'string' || Buffer.isBuffer(obj))
+            return obj;
+        if (typeof obj === 'number')
+            return obj.toString();
+        return JSON.stringify(obj);
+    };
+    
 }
 
 
 
 module.exports = MojaloopRequests;
+

--- a/src/lib/mojaloop-requests/mojaloopRequests.js
+++ b/src/lib/mojaloop-requests/mojaloopRequests.js
@@ -23,6 +23,7 @@ const throwOrJson = common.throwOrJson;
 
 const JwsSigner = require('../jws').signer;
 
+const bodyStringifier = require('./toString');
 
 /**
  * A class for making outbound requests with mutually authenticated TLS and JWS signing
@@ -227,6 +228,8 @@ class MojaloopRequests {
             this.jwsSigner.sign(reqOpts);
         }
 
+        reqOpts.body = bodyStringifier(reqOpts.body);
+
         try {
             this.logger.log(`Executing HTTP PUT: ${util.inspect(reqOpts)}`);
             return await request(reqOpts).then(throwOrJson);
@@ -252,6 +255,8 @@ class MojaloopRequests {
         if(this.jwsSign) {
             this.jwsSigner.sign(reqOpts);
         }
+
+        reqOpts.body = bodyStringifier(reqOpts.body);
 
         try {
             this.logger.log(`Executing HTTP POST: ${util.inspect(reqOpts)}`);

--- a/src/lib/mojaloop-requests/toString.js
+++ b/src/lib/mojaloop-requests/toString.js
@@ -1,0 +1,9 @@
+var Buffer = require('buffer').Buffer;
+
+module.exports = function toString(obj) {
+    if (typeof obj === 'string')
+        return obj;
+    if (typeof obj === 'number' || Buffer.isBuffer(obj))
+        return obj.toString();
+    return JSON.stringify(obj);
+};

--- a/src/lib/mojaloop-requests/toString.js
+++ b/src/lib/mojaloop-requests/toString.js
@@ -1,8 +1,0 @@
-
-module.exports = function toString(obj) {
-    if (typeof obj === 'string' || Buffer.isBuffer(obj))
-        return obj;
-    if (typeof obj === 'number')
-        return obj.toString();
-    return JSON.stringify(obj);
-};

--- a/src/lib/mojaloop-requests/toString.js
+++ b/src/lib/mojaloop-requests/toString.js
@@ -1,9 +1,8 @@
-var Buffer = require('buffer').Buffer;
 
 module.exports = function toString(obj) {
-    if (typeof obj === 'string')
+    if (typeof obj === 'string' || Buffer.isBuffer(obj))
         return obj;
-    if (typeof obj === 'number' || Buffer.isBuffer(obj))
+    if (typeof obj === 'number')
         return obj.toString();
     return JSON.stringify(obj);
 };

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "8.1.1-snapshot",
+  "version": "8.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
...even if not doing jwsSigning.

This prevents an error when calling a method like `postTransfers` with an object body and with jwsSign disabled. The more primitive methods like `_put` and `_post` will send an Object to `request` which will throw:

`TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be one of type string or Buffer. Received type object`