### PR TITLE
Add httpResponse code for ID_NOT_FOUND error

### DIFF
--- a/src/lib/errors/index.js
+++ b/src/lib/errors/index.js
@@ -51,7 +51,7 @@ const MojaloopApiErrorCodes = {
     MISSING_MANDATORY_EXTENSION:      { code: '3107', message: 'Missing mandatory extension parameter', httpStatusCode: 400 },
 
     //identifier errors
-    ID_NOT_FOUND:                     { code: '3200', message: 'Generic ID not found', httpStatusCode: 404 },
+    ID_NOT_FOUND:                     { code: '3200', message: 'Generic ID not found', httpStatusCode: 202 },
     DESTINATION_FSP_ERROR:            { code: '3201', message: 'Destination FSP Error' },
     PAYER_FSP_ID_NOT_FOUND:           { code: '3202', message: 'Payer FSP ID not found' },
     PAYEE_FSP_ID_NOT_FOUND:           { code: '3203', message: 'Payee FSP ID not found' },

--- a/src/lib/errors/index.js
+++ b/src/lib/errors/index.js
@@ -51,7 +51,7 @@ const MojaloopApiErrorCodes = {
     MISSING_MANDATORY_EXTENSION:      { code: '3107', message: 'Missing mandatory extension parameter', httpStatusCode: 400 },
 
     //identifier errors
-    ID_NOT_FOUND:                     { code: '3200', message: 'Generic ID not found' },
+    ID_NOT_FOUND:                     { code: '3200', message: 'Generic ID not found', httpStatusCode: 404 },
     DESTINATION_FSP_ERROR:            { code: '3201', message: 'Destination FSP Error' },
     PAYER_FSP_ID_NOT_FOUND:           { code: '3202', message: 'Payer FSP ID not found' },
     PAYEE_FSP_ID_NOT_FOUND:           { code: '3203', message: 'Payee FSP ID not found' },

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "7.5.0",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Related issue: https://github.com/mojaloop/project/issues/981

Set `httpResponseCode` for `ID_NOT_FOUND` error.