### PR TITLE
Add POST individual participant endpoint

### DIFF
--- a/src/lib/mojaloop-requests/mojaloopRequests.js
+++ b/src/lib/mojaloop-requests/mojaloopRequests.js
@@ -113,6 +113,15 @@ class MojaloopRequests {
     }
 
     /**
+     * Executes a POST /participants/{idType}/{idValue} request for identifier type and identifier
+     *
+     * @returns {object} - JSON response body if one was received
+     */
+    async postParticipantsIndividual(idType, idValue, body, destFspId) {
+        return this._post(`participants/${idType}/${idValue}`, 'participants', body, destFspId);
+    }
+
+    /**
      * Executes a PUT /participants request for the specified identifier type and indentifier
      */
     async putParticipants(idType, idValue, body, destFspId) {
@@ -324,7 +333,7 @@ class MojaloopRequests {
             return obj.toString();
         return JSON.stringify(obj);
     }
-    
+
 }
 
 


### PR DESCRIPTION
Currently only bulk participants is supported. This adds a function to call a post to add an individual participant at the ALS.

Ideally `postParticipants` would be the singular and current `postParticipants` would be renamed `postParticipantsBulk`. But I suspect that would cause backwards compatibility issues for wherever this library is used.