### PR TITLE
feat (Payee Initiated):

### DIFF
--- a/src/lib/mojaloop-requests/mojaloopRequests.js
+++ b/src/lib/mojaloop-requests/mojaloopRequests.js
@@ -223,7 +223,7 @@ class MojaloopRequests {
      * @returns {object} - JSON response body if one was received
      */
     async getAuthorizations(transactionRequestId, authorizationParameters, destFspId) {
-        const url = `authorizations/${transactionRequestId}?${authorizationParameters}`
+        const url = `authorizations/${transactionRequestId}?${authorizationParameters}`;
         return this._get(url , 'authorizations', destFspId);
     }
 

--- a/src/lib/mojaloop-requests/mojaloopRequests.js
+++ b/src/lib/mojaloop-requests/mojaloopRequests.js
@@ -67,6 +67,7 @@ class MojaloopRequests {
         this.alsEndpoint = config.alsEndpoint ? `${this.transportScheme}://${config.alsEndpoint}` : null;
         this.quotesEndpoint = config.quotesEndpoint ? `${this.transportScheme}://${config.quotesEndpoint}` : null;
         this.transfersEndpoint = config.transfersEndpoint ? `${this.transportScheme}://${config.transfersEndpoint}` : null;
+        this.transactionRequestsEndpoint = config.transactionRequestsEndpoint ? `${this.transportScheme}://${config.transactionRequestsEndpoint}` : null;
 
         this.wso2Auth = config.wso2Auth;
     }
@@ -217,6 +218,34 @@ class MojaloopRequests {
     }
 
     /**
+     * Executes a GET /authorizations request for the specified transactionRequestId
+     *
+     * @returns {object} - JSON response body if one was received
+     */
+    async getAuthorizations(transactionRequestId, authorizationParameters, destFspId) {
+        const url = `authorizations/${transactionRequestId}?${authorizationParameters}`
+        return this._get(url , 'authorizations', destFspId);
+    }
+
+    /**
+     * Executes a PUT /authorizations/{ID} request for the specified transactionRequestId
+     *
+     * @returns {object} - JSON response body if one was received
+     */
+    async putAuthorizations(transactionRequestId, authorizationResponse, destFspId) {
+        return this._put(`authorizations/${transactionRequestId}`, 'authorizations', authorizationResponse, destFspId);
+    }
+
+    /**
+     * Executes a PUT /authorizations/{ID}/error request for the specified transactionRequestId
+     *
+     * @returns {object} - JSON response body if one was received
+     */
+    async putAuthorizationsError(transactionRequestId, error, destFspId) {
+        return this._put(`authorizations/${transactionRequestId}/error`, 'authorizations', error, destFspId);
+    }
+
+    /**
      * Utility function for building outgoing request headers as required by the mojaloop api spec
      *
      * @returns {object} - headers object for use in requests to mojaloop api endpoints
@@ -265,6 +294,12 @@ class MojaloopRequests {
                 break;
             case 'transfers':
                 returnEndpoint = this.transfersEndpoint ? this.transfersEndpoint : this.peerEndpoint;
+                break;
+            case 'transactionRequests':
+                returnEndpoint = this.transactionRequestsEndpoint ? this.transactionRequestsEndpoint : this.peerEndpoint;
+                break;
+            case 'authorizations':
+                returnEndpoint = this.transactionRequestsEndpoint ? this.transactionRequestsEndpoint : this.peerEndpoint;
                 break;
             default:
                 returnEndpoint = this.peerEndpoint;


### PR DESCRIPTION
* Add ability to configure endpoint for the transactionRequestsEndpoint
* Default transactionRequests and authorizations to use transactionRequestsEndpoint
* Add authorization methods

Note that authorization requests use the transactionRequestId as an identifier [Example](https://github.com/mojaloop/mojaloop-specification/blob/master/documents/API%20Definition%20v1.0.md#6621-get-authorizationsid)