### PR TITLE
fixed the different request object issue

### DIFF
--- a/src/lib/jws/jwsSigner.js
+++ b/src/lib/jws/jwsSigner.js
@@ -44,13 +44,13 @@ class JwsSigner {
     sign(requestOptions) {
         this.logger.log(`JWS Signing request: ${util.inspect(requestOptions)}`);
 
-        if(!requestOptions.body) {
+        if(!(requestOptions.body || requestOptions.data)) {
             throw new Error('Cannot sign with no body');
         }
 
-        const uriMatches = uriRegex.exec(requestOptions.uri);
+        const uriMatches = uriRegex.exec(requestOptions.uri || requestOptions.url);
         if(!uriMatches || uriMatches.length < 2) {
-            throw new Error(`URI not valid for protected header: ${requestOptions.uri}`);
+            throw new Error(`URI not valid for protected header: ${requestOptions.uri || requestOptions.url}`);
         }
 
         // add required JWS headers to the request options
@@ -81,7 +81,7 @@ class JwsSigner {
         // now we sign
         const token = jws.sign({
             header: protectedHeaderObject,
-            payload: requestOptions.body,
+            payload: requestOptions.body || requestOptions.data,
             secret: this.signingKey,
             encoding: 'utf8'});
 
@@ -95,7 +95,9 @@ class JwsSigner {
 
         requestOptions.headers['fspiop-signature'] = JSON.stringify(signatureObject);
 
-        requestOptions.body = JSON.stringify(requestOptions.body);
+        if(typeof(requestOptions.body || requestOptions.data) !== 'string') {
+            requestOptions.body = JSON.stringify(requestOptions.body || requestOptions.data);
+        }
     }
 }
 

--- a/src/lib/jws/jwsSigner.js
+++ b/src/lib/jws/jwsSigner.js
@@ -38,8 +38,9 @@ class JwsSigner {
     /**
      * Adds JWS headers to an outgoing HTTP request options object
      *
-     * @param requestOptions {object} a request-promise-native request options object
+     * @param requestOptions {object} a request-promise-native/axios style request options object
      *   (see https://github.com/request/request-promise-native)
+     *   (see https://github.com/axios/axios)
      */
     sign(requestOptions) {
         this.logger.log(`JWS Signing request: ${util.inspect(requestOptions)}`);
@@ -59,6 +60,40 @@ class JwsSigner {
         requestOptions.headers['fspiop-http-method'] = requestOptions.method.toUpperCase();
         requestOptions.headers['fspiop-uri'] = uriMatches[1];
 
+        // get the signature and add it to the header
+        requestOptions.headers['fspiop-signature'] = this.getSignature(requestOptions);
+
+        if(requestOptions.body && typeof(requestOptions.body) !== 'string') {
+            requestOptions.body = JSON.stringify(requestOptions.body);
+        }
+        if(requestOptions.data && typeof(requestOptions.data) !== 'string') {
+            requestOptions.data = JSON.stringify(requestOptions.data);
+        }
+    }
+
+    /**
+     * Returns JWS signature for an outgoing HTTP request options object
+     *
+     * @param requestOptions {object} a request-promise-native/axios style request options object
+     *   (see https://github.com/request/request-promise-native)
+     *   (see https://github.com/axios/axios)
+     *
+     * @returns {string} - JWS Signature as a string 
+    */
+    getSignature(requestOptions) {
+        this.logger.log(`Get JWS Signature: ${util.inspect(requestOptions)}`);
+        const payload = requestOptions.body || requestOptions.data;
+        const uri = requestOptions.uri || requestOptions.url;
+
+        if(!payload) {
+            throw new Error('Cannot sign with no body');
+        }
+
+        const uriMatches = uriRegex.exec(uri);
+        if(!uriMatches || uriMatches.length < 2) {
+            throw new Error(`URI not valid for protected header: ${uri}`);
+        }
+
         // generate the protected header as base64url encoding of UTF-8 encoding of JSON string
 
         // Note: Property names are case sensitive in the protected header object even though they are
@@ -66,20 +101,20 @@ class JwsSigner {
         const protectedHeaderObject = {
             alg: SIGNATURE_ALGORITHM,
             'FSPIOP-URI': requestOptions.headers['fspiop-uri'],
-            'FSPIOP-HTTP-Method': requestOptions.headers['fspiop-http-method'],
+            'FSPIOP-HTTP-Method': requestOptions.method.toUpperCase(),
             'FSPIOP-Source': requestOptions.headers['fspiop-source']
         };
 
         // set destination in the protected header object if it is present in the request headers
-        if(requestOptions.headers['fspiop-destination']) {
+        if (requestOptions.headers['fspiop-destination']) {
             protectedHeaderObject['FSPIOP-Destination'] = requestOptions.headers['fspiop-destination'];
         }
 
         // set date in the protected header object if it is present in the request headers
-        if(requestOptions.headers['date']) {
+        if (requestOptions.headers['date']) {
             protectedHeaderObject['Date'] = requestOptions.headers['date'];
         }
-
+        
         // now we sign
         const token = jws.sign({
             header: protectedHeaderObject,
@@ -95,14 +130,7 @@ class JwsSigner {
             protectedHeader: protectedHeaderBase64.replace('"', '')
         };
 
-        requestOptions.headers['fspiop-signature'] = JSON.stringify(signatureObject);
-
-        if(requestOptions.body && typeof(requestOptions.body) !== 'string') {
-            requestOptions.body = JSON.stringify(requestOptions.body);
-        }
-        if(requestOptions.data && typeof(requestOptions.data) !== 'string') {
-            requestOptions.data = JSON.stringify(requestOptions.data);
-        }
+        return JSON.stringify(signatureObject);
     }
 }
 

--- a/src/lib/jws/jwsSigner.js
+++ b/src/lib/jws/jwsSigner.js
@@ -97,10 +97,10 @@ class JwsSigner {
 
         requestOptions.headers['fspiop-signature'] = JSON.stringify(signatureObject);
 
-        if(typeof(requestOptions.body) !== 'string') {
+        if(requestOptions.body && typeof(requestOptions.body) !== 'string') {
             requestOptions.body = JSON.stringify(requestOptions.body);
         }
-        if(typeof(requestOptions.data) !== 'string') {
+        if(requestOptions.data && typeof(requestOptions.data) !== 'string') {
             requestOptions.data = JSON.stringify(requestOptions.data);
         }
     }

--- a/src/lib/jws/jwsSigner.js
+++ b/src/lib/jws/jwsSigner.js
@@ -43,14 +43,16 @@ class JwsSigner {
      */
     sign(requestOptions) {
         this.logger.log(`JWS Signing request: ${util.inspect(requestOptions)}`);
+        const payload = requestOptions.body || requestOptions.data;
+        const uri = requestOptions.uri || requestOptions.url;
 
-        if(!(requestOptions.body || requestOptions.data)) {
+        if(!payload) {
             throw new Error('Cannot sign with no body');
         }
 
-        const uriMatches = uriRegex.exec(requestOptions.uri || requestOptions.url);
+        const uriMatches = uriRegex.exec(uri);
         if(!uriMatches || uriMatches.length < 2) {
-            throw new Error(`URI not valid for protected header: ${requestOptions.uri || requestOptions.url}`);
+            throw new Error(`URI not valid for protected header: ${uri}`);
         }
 
         // add required JWS headers to the request options
@@ -81,7 +83,7 @@ class JwsSigner {
         // now we sign
         const token = jws.sign({
             header: protectedHeaderObject,
-            payload: requestOptions.body || requestOptions.data,
+            payload,
             secret: this.signingKey,
             encoding: 'utf8'});
 
@@ -95,8 +97,11 @@ class JwsSigner {
 
         requestOptions.headers['fspiop-signature'] = JSON.stringify(signatureObject);
 
-        if(typeof(requestOptions.body || requestOptions.data) !== 'string') {
-            requestOptions.body = JSON.stringify(requestOptions.body || requestOptions.data);
+        if(typeof(requestOptions.body) !== 'string') {
+            requestOptions.body = JSON.stringify(requestOptions.body);
+        }
+        if(typeof(requestOptions.data) !== 'string') {
+            requestOptions.data = JSON.stringify(requestOptions.data);
         }
     }
 }

--- a/src/lib/jws/jwsValidator.js
+++ b/src/lib/jws/jwsValidator.js
@@ -40,8 +40,8 @@ class JwsValidator {
     validate(request) {
         try {
             const { headers, body, data } = request;
-
-            if(!(body || data)) {
+            const payload = body || data;
+            if(!payload) {
                 throw new Error('Cannot validate JWS without a body');
             }
 
@@ -65,7 +65,7 @@ class JwsValidator {
             const signatureHeader = JSON.parse(headers['fspiop-signature']);
             const { protectedHeader, signature } = signatureHeader;
 
-            const token = `${protectedHeader}.${base64url(JSON.stringify(body || data))}.${signature}`; 
+            const token = `${protectedHeader}.${base64url(JSON.stringify(payload))}.${signature}`; 
 
             // validate signature
             const result = jwt.verify(token, pubKey, { complete: true });

--- a/src/lib/jws/jwsValidator.js
+++ b/src/lib/jws/jwsValidator.js
@@ -39,9 +39,9 @@ class JwsValidator {
      */
     validate(request) {
         try {
-            const { headers, body } = request;
+            const { headers, body, data } = request;
 
-            if(!body) {
+            if(!(body || data)) {
                 throw new Error('Cannot validate JWS without a body');
             }
 
@@ -65,7 +65,7 @@ class JwsValidator {
             const signatureHeader = JSON.parse(headers['fspiop-signature']);
             const { protectedHeader, signature } = signatureHeader;
 
-            const token = `${protectedHeader}.${base64url(JSON.stringify(body))}.${signature}`; 
+            const token = `${protectedHeader}.${base64url(JSON.stringify(body || data))}.${signature}`; 
 
             // validate signature
             const result = jwt.verify(token, pubKey, { complete: true });

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "9.1.6",
+  "version": "9.1.7",
   "description": "An set of standard components for connecting to Mojaloop API enabled switches",
   "main": "index.js",
   "scripts": {

--- a/src/test/unit/jws.test.js
+++ b/src/test/unit/jws.test.js
@@ -63,6 +63,7 @@ describe('JWS', () => {
             signingKey: signingKey
         });
         body = { test: 123 };
+        // An request-promise-native style request uses the `.uri` and `.body` properties instead of the `.url` and `.data` properties.
         testOpts = {
             headers: {
                 'fspiop-source': 'mojaloop-sdk',
@@ -73,6 +74,7 @@ describe('JWS', () => {
             uri: 'https://someswitch.com:443/prefix/parties/MSISDN/12345678',
             body,
         };
+        // An axios-style request uses the `.url` and `.data` properties instead of the `.uri` and `.body` properties.
         testOptsData = {
             headers: {
                 'fspiop-source': 'mojaloop-sdk',

--- a/src/test/unit/jws.test.js
+++ b/src/test/unit/jws.test.js
@@ -132,7 +132,7 @@ describe('JWS', () => {
     }
 
 
-    test('Should generate valid JWS headers and signature for request with data', () => {
+    test('Should generate valid JWS headers and signature for request with body', () => {
         signer.sign(testOpts);
 
         expect(testOpts.headers['fspiop-signature']).toBeTruthy();
@@ -152,12 +152,52 @@ describe('JWS', () => {
         testValidateSignedRequestData(false);
     });
 
+    test('getSignature Should return valid JWS signature for request with body', () => {
+        testOpts.headers['fspiop-uri'] = '/parties/MSISDN/12345678';
+        testOpts.headers['fspiop-http-method'] = 'PUT';
+        const signature = signer.getSignature(testOpts);
+        testOpts.headers['fspiop-signature'] = signature;
+
+        expect(signature).toBeTruthy();
+        testValidateSignedRequest(false);
+    });
+
+    test('getSignature Should return valid JWS signature for request with data', () => {
+        testOptsData.headers['fspiop-uri'] = '/parties/MSISDN/12345678';
+        testOptsData.headers['fspiop-http-method'] = 'PUT';
+        const signature = signer.getSignature(testOptsData);
+        testOptsData.headers['fspiop-signature'] = signature;
+
+        expect(signature).toBeTruthy();
+        testValidateSignedRequestData(false);
+    });
+
 
     test('Should throw when trying to sign with no body', () => {
         delete testOpts.body;
 
         expect(() => {
             signer.sign(testOpts);
+        }).toThrow();
+    });
+
+    test('getSignature Should throw when trying to sign with no body', () => {
+        delete testOpts.body;
+        testOpts.headers['fspiop-uri'] = '/parties/MSISDN/12345678';
+        testOpts.headers['fspiop-http-method'] = 'PUT';
+
+        expect(() => {
+            signer.getSignature(testOpts);
+        }).toThrow();
+    });
+
+    test('getSignature Should throw when trying to sign with no body(data)', () => {
+        delete testOptsData.data;
+        testOptsData.headers['fspiop-uri'] = '/parties/MSISDN/12345678';
+        testOptsData.headers['fspiop-http-method'] = 'PUT';
+
+        expect(() => {
+            signer.getSignature(testOptsData);
         }).toThrow();
     });
 
@@ -177,11 +217,27 @@ describe('JWS', () => {
         }).toThrow();
     });
 
+    test('getSignature Should throw when trying to sign with no uri', () => {
+        delete testOpts.uri;
+
+        expect(() => {
+            signer.getSignature(testOpts);
+        }).toThrow();
+    });
+
     test('Should throw when trying to sign with no url', () => {
         delete testOptsData.url;
 
         expect(() => {
             signer.sign(testOptsData);
+        }).toThrow();
+    });
+
+    test('getSignature Should throw when trying to sign with no url', () => {
+        delete testOptsData.url;
+
+        expect(() => {
+            signer.getSignature(testOptsData);
         }).toThrow();
     });
 


### PR DESCRIPTION
There are multiple libs for making http callbacks
This JWS lib is catering to request options having `body` as the request body (e.g. `request-promise-native` )

Added the feature to handle the request options having `data`  (e.g `axios`)

Same is the case of `uri` vs `url`.

2.  Most of the times the body is already stringified, so we needsto check the typeof body before stringify