### PR TITLE
Fix: Modify transaction authorization challenge spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Mojaloop DFSP SDK Standard Components
 
-This package contains a set of  components that encode standard practices for enabling the following features of a DFSP to Mojaloop switch interface:
+This package contains a set of components that encode standard practices for enabling the following features of a DFSP to Mojaloop switch interface:
 
 ## Usage
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -178,10 +178,7 @@ declare namespace SDKStandardComponents {
     }
 
     type putThirdpartyRequestsTransactionsAuthorizationsRequest = {
-        challenge: {
-            payload: string;
-            signature: string | null;
-        }
+        challenge: string;
         consentId: string;
         sourceAccountId: string;
         status: 'PENDING' | 'VERIFIED';
@@ -198,10 +195,7 @@ declare namespace SDKStandardComponents {
     }
 
     type postThirdpartyRequestsTransactionsAuthorizationsRequest = {
-        challenge: {
-            payload: string;
-            signature: string | null;
-        }
+        challenge: string;
         consentId: string;
         sourceAccountId: string;
         status: 'PENDING' | 'VERIFIED';

--- a/src/test/unit/data/postThirdpartyRequestsTransactionAuthorization.json
+++ b/src/test/unit/data/postThirdpartyRequestsTransactionAuthorization.json
@@ -1,8 +1,5 @@
 {
-    "challenge": {
-        "payload": "1os7Vh8iQ2ycMdwtA8v1SA==",
-        "signature": "MgNVUQgfELLVYI4IFt2BEw=="
-    },
+    "challenge": "MgNVUQgfELLVYI4IFt2BEw==",
     "value": "X4eAlhPYXpytan9QC7u5Cw==",
     "consentId": "111",
     "sourceAccountId": "dfspa.1111-2222",

--- a/src/test/unit/data/putThirdpartyRequestsTransactionAuthorization.json
+++ b/src/test/unit/data/putThirdpartyRequestsTransactionAuthorization.json
@@ -1,8 +1,5 @@
 {
-    "challenge": {
-        "payload": "1os7Vh8iQ2ycMdwtA8v1SA==",
-        "signature": "MgNVUQgfELLVYI4IFt2BEw=="
-    },
+    "challenge": "MgNVUQgfELLVYI4IFt2BEw==",
     "value": "X4eAlhPYXpytan9QC7u5Cw==",
     "consentId": "111",
     "sourceAccountId": "dfspa.1111-2222",


### PR DESCRIPTION
This PR updates the ThirdPartyRequests method according to the latest sequence diagrams for
 - `POST /thirdpartyRequests/transactions/{id}/authorizations` incoming request for the `Auth-Service`
 - `PUT /thirdpartyRequests/transactions/{id}/authorizations` outgoing request from the `Auth-Service`

This change is based on the latest PISP sequence diagrams: https://github.com/mojaloop/pisp/blob/master/docs/out/transfer/api_calls_detailed/PISPTransferDetailedAPI-page2.png