### PR TITLE
Add PUT /thirdpartyRequest/transactions/{ID}/authorizations/error request

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -316,6 +316,17 @@ declare namespace SDKStandardComponents {
          * @returns {Promise<object>} JSON response body if one was received
          */
         putThirdpartyRequestsTransactionsAuthorizations(thirdpartyRequestsTransactionsBody: putThirdpartyRequestsTransactionsAuthorizationsRequest, transactionRequestId: string, destParticipantId: string): Promise<GenericRequestResponse | MojaloopRequestResponse>;
+
+        /**
+         * @function putThirdpartyRequestsTransactionsAuthorizationsError
+         * @description
+         *   Executes a `PUT thirdpartyRequests/transactions/${transactionRequestId}/authorizations/error` request
+         * @param {putThirdpartyRequestsTransactionsAuthorizationsRequest} thirdpartyRequestsTransactionsBody The thirdpartyRequestsTransactionsBody
+         * @param {string} transactionRequestId The `id` of the transactionRequest/thirdpartyRequest
+         * @param {string} destParticipantId The id of the destination participant, in this case, a DFSP
+         * @returns {Promise<object>} JSON response body if one was received
+         */
+        putThirdpartyRequestsTransactionsAuthorizationsError(thirdpartyRequestsTransactionsBody: TErrorInformationObject, transactionRequestId: string, destParticipantId: string): Promise<GenericRequestResponse | MojaloopRequestResponse>;
     }
 }
 

--- a/src/lib/requests/thirdpartyRequests.js
+++ b/src/lib/requests/thirdpartyRequests.js
@@ -54,6 +54,11 @@ class ThirdpartyRequests extends BaseRequests {
         const url = `thirdpartyRequests/transactions/${transactionRequestId}/authorizations`;
         return this._put(url, 'thirdparty', thirdpartyRequestsTransactionsBody, destParticipantId);
     }
+
+    async putThirdpartyRequestsTransactionsAuthorizationsError(thirdpartyRequestsTransactionsBody, transactionRequestId, destParticipantId) {
+        const url = `thirdpartyRequests/transactions/${transactionRequestId}/authorizations/error`;
+        return this._put(url, 'thirdparty', thirdpartyRequestsTransactionsBody, destParticipantId);
+    }
 }
 
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "10.6.6",
+  "version": "10.6.7",
   "description": "A set of standard components for connecting to Mojaloop API enabled Switches",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/test/unit/data/putThirdpartyRequestTransactionAuthorizationsError.json
+++ b/src/test/unit/data/putThirdpartyRequestTransactionAuthorizationsError.json
@@ -1,0 +1,14 @@
+{
+    "errorInformation": {
+        "errorCode":"6000",
+        "errorDescription":"Generic third party error.",
+        "extensionList":{
+            "extension":[
+                {
+                    "key":"errorDescription",
+                    "value":"This is a more detailed error description"
+                }
+            ]
+        }
+    }
+}

--- a/src/test/unit/lib/requests/thirdpartyRequests.test.js
+++ b/src/test/unit/lib/requests/thirdpartyRequests.test.js
@@ -481,6 +481,7 @@ describe('ThirdpartyRequests', () => {
 
     describe('putThirdpartyRequestsTransactionsAuthorizations', () => {
         const putTransactionsAuthorizationsRequest = require('../../data/putThirdpartyRequestsTransactionAuthorization.json');
+        const putErrorRequest = require('../../data/putThirdpartyRequestTransactionAuthorizationsError.json');
         const wso2Auth = new WSO2Auth({ logger: mockLogger({app: 'get-thirdparty-request-transaction-authorization-test'})});
         const config = {
             logger: mockLogger({ app: 'putThirdpartyRequestsTransactionAuthorization-test' }),
@@ -520,6 +521,34 @@ describe('ThirdpartyRequests', () => {
                     'path': '/thirdpartyRequests/transactions/1/authorizations',
                     'headers': expect.objectContaining({
                         'fspiop-destination': 'dfspa'
+                    })
+                })
+            );
+        });
+
+        it('executes a `PUT /thirdpartyRequests/transactions/{ID}/authorizations/error` request', async () => {
+            // Arrange
+            http.__request = jest.fn(() => ({
+                statusCode: 202,
+                headers: {
+                    'content-length': 0
+                },
+            }));
+            const tpr = new ThirdpartyRequests(config);
+            const requestBody = putErrorRequest;
+            const transactionRequestId = 1;
+
+            // Act
+            await tpr.putThirdpartyRequestsTransactionsAuthorizationsError(requestBody, transactionRequestId, 'pispa');
+
+            // Assert
+            expect(http.__write).toHaveBeenCalledWith((JSON.stringify(requestBody)));
+            expect(http.__request).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    'method': 'PUT',
+                    'path': '/thirdpartyRequests/transactions/1/authorizations/error',
+                    'headers': expect.objectContaining({
+                        'fspiop-destination': 'pispa'
                     })
                 })
             );


### PR DESCRIPTION
This PR adds `PUT /thirdpartyRequest/transactions/{ID}/authorizations/error` request for notifying other participants about errors in transaction verification process.