### PR TITLE
Update Type Definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -138,7 +138,7 @@ declare namespace SDKStandardComponents {
         initiatorId: string;
         participantId: string;
         scopes: TCredentialScope[];
-        credential: TCredential;
+        credential?: TCredential;
     }
 
     type PutConsentRequestsRequest = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -146,7 +146,7 @@ declare namespace SDKStandardComponents {
         authChannels: TAuthChannel[];
         scopes: TCredentialScope[];
         callbackUri: string;
-        authUri: string;
+        authUri: string | null;
         authToken: string;
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -217,10 +217,10 @@ declare namespace SDKStandardComponents {
         quoteId: string;
         transactionId: string;
         transactionRequestId: string;
-        payee: Party;
-        payer: Party;
-        amountType: AmountType;
-        amount: Money;
+        payee: TParty;
+        payer: TParty;
+        amountType: TAmountType;
+        amount: TMoney;
         transactionType: TransactionType;
         note: string;
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -135,7 +135,6 @@ declare namespace SDKStandardComponents {
 
     type PutConsentRequestsRequest = {
         initiatorId: string;
-        accountIds: string[];
         authChannels: TAuthChannel[];
         scopes: string[];
         callbackUri: string;
@@ -146,7 +145,6 @@ declare namespace SDKStandardComponents {
     type PostConsentRequestsRequest = {
         id: string;
         initiatorId: string;
-        accountIds: string[];
         authChannels: TAuthChannel[];
         scopes: string[];
         callbackUri: string;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "description": "A set of standard components for connecting to Mojaloop API enabled Switches",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
* Updated Type Definitions according to Linking Diagram
* Fixed Type Errors
(Will update linking diagram to change credential from `null` to `undefined` - based on conversation with @jgeewax )

Note: 
Unable to fix the missing TransactionType type for PostQuotesRequest  - not sure what/where that's supposed to be - will create an issue once this PR is approved