### PR TITLE
fix(types): bad logger type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,20 @@ jobs:
       - store_artifacts:
           path: /lintresults
 
+  build-typescript:
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
+    steps:
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - checkout
+      - restore_cache:
+          keys:
+          - dependency-cache-1-{{ checksum "src/package.json" }}
+      - run:
+          name: Run the ts compiler
+          command: cd src && npm run build
 
 
 #  test-coverage:
@@ -267,6 +281,17 @@ workflows:
               ignore:
                 - /feature*/
                 - /bugfix*/
+      - build-typescript:
+          context: org-global
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /feature*/
+                - /bugfix*/
 
 #      - test-coverage:
 #          context: org-global
@@ -306,6 +331,7 @@ workflows:
           requires:
             - setup
             - test-unit
+            - build-typescript
 #            - test-coverage
 #            - vulnerability-check
 #            - audit-licenses
@@ -320,6 +346,7 @@ workflows:
           requires:
             - setup
             - test-unit
+            - build-typescript
 #            - test-coverage
 #            - vulnerability-check
 #            - audit-licenses

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -649,7 +649,7 @@ declare namespace SDKStandardComponents {
 
         interface LoggerOptions {
             allowContextOverwrite: boolean
-            copy: (unknown) => unknown
+            copy: (arg0: unknown) => unknown
             levels: Level[]
         }
 
@@ -721,7 +721,7 @@ declare namespace SDKStandardComponents {
 
     namespace requests {
         namespace common {
-            function bodyStringifier(unknown): string | Buffer 
+            function bodyStringifier(arg0: unknown): string | Buffer 
         }
     }
 

--- a/src/package.json
+++ b/src/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
+    "build": "tsc -p ./tsconfig.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "jest --ci --collectCoverage=false --reporters=default --reporters=jest-junit --env=node --runInBand test/unit",
@@ -33,12 +34,13 @@
   },
   "devDependencies": {
     "@types/jest": "^25.2.1",
-    "@types/node": "^14.6.3",
+    "@types/node": "^14.11.8",
     "eslint": "7.0.0",
     "eslint-config-airbnb-base": "14.1.0",
     "eslint-plugin-import": "2.20.2",
     "jest": "^26.4.2",
     "jest-junit": "^10.0.0",
-    "nock": "^12.0.3"
+    "nock": "^12.0.3",
+    "typescript": "^4.0.3"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "12.0.1",
+  "version": "12.1.1",
   "description": "A set of standard components for connecting to Mojaloop API enabled Switches",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -10,16 +10,13 @@
   "compilerOptions": {
     "target": "es2018",
     "module": "commonjs",
-    "rootDirs": [
-      "src",
-      "test"
-    ],
     "lib": [
       "esnext"
     ],
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
+    "noEmit": true,
     "rootDir": "./",
     "outDir": "dist",
     "strict": true,

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,46 @@
+{
+  "include": [
+    "index.d.ts",
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "coverage"
+  ],
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "rootDirs": [
+      "src",
+      "test"
+    ],
+    "lib": [
+      "esnext"
+    ],
+    "importHelpers": true,
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "./",
+    "outDir": "dist",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "~/*": [
+        "src/*"
+      ]
+    },
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
- fixes error in `index.d.ts`
- adds  a simple `npm run build` step to help us verify our `index.d.ts` files
- adds typescript compiler check to ci/cd pipelines
