### PR TITLE
feat: add initial generic thirdparty error codes

### DIFF
--- a/src/lib/errors/index.js
+++ b/src/lib/errors/index.js
@@ -94,7 +94,18 @@ const MojaloopApiErrorCodes = {
     PAYEE_UNSUPPORTED_CURRENCY:       { code: '5106', message: 'Payee unsupported currency' },
     PAYEE_LIMIT_ERROR:                { code: '5200', message: 'Payee limit error' },
     PAYEE_PERMISSION_ERROR:           { code: '5300', message: 'Payee permission error' },
-    GENERIC_PAYEE_BLOCKED_ERROR:      { code: '5400', message: 'Generic Payee blocked error' }
+    GENERIC_PAYEE_BLOCKED_ERROR:      { code: '5400', message: 'Generic Payee blocked error' },
+
+    // thirdparty errors - WIP
+    THIRDPARTY_ERROR:                 { code: '7000', message: 'Generic Thirdparty error' },
+    THIRDPARTY_TRANSACTION_ERROR:     { code: '7100', message: 'Generic Thirdparty transaction error' },
+    THIRDPARTY_AUTHENTICATION_ERROR:  { code: '7200', message: 'Generic Thirdparty authentication error' },
+    THIRDPARTY_AUTHORIZATION_ERROR:   { code: '7300', message: 'Generic Thirdparty authorization error' },
+    THIRDPARTY_ACCOUNT_LINKING_ERROR: { code: '7500', message: 'Generic Thirdparty account linking error' },
+    THIRDPARTY_ACCOUNTS_ERROR:        { code: '7600', message: 'Generic Thirdparty accounts error' },
+    THIRDPARTY_CONSENT_ERROR:         { code: '7700', message: 'Generic Thirdparty consent error' },
+    THIRDPARTY_CONSENT_REQUEST_ERROR: { code: '7800', message: 'Generic Thirdparty consent request error' },
+    THIRDPARTY_CREDENTIAL_ERROR:      { code: '7900', message: 'Generic Thirdparty credential error' },
 };
 
 

--- a/src/lib/errors/index.js
+++ b/src/lib/errors/index.js
@@ -99,13 +99,8 @@ const MojaloopApiErrorCodes = {
     // thirdparty errors - WIP
     THIRDPARTY_ERROR:                 { code: '7000', message: 'Generic Thirdparty error' },
     THIRDPARTY_TRANSACTION_ERROR:     { code: '7100', message: 'Generic Thirdparty transaction error' },
-    THIRDPARTY_AUTHENTICATION_ERROR:  { code: '7200', message: 'Generic Thirdparty authentication error' },
-    THIRDPARTY_AUTHORIZATION_ERROR:   { code: '7300', message: 'Generic Thirdparty authorization error' },
-    THIRDPARTY_ACCOUNT_LINKING_ERROR: { code: '7500', message: 'Generic Thirdparty account linking error' },
-    THIRDPARTY_ACCOUNTS_ERROR:        { code: '7600', message: 'Generic Thirdparty accounts error' },
-    THIRDPARTY_CONSENT_ERROR:         { code: '7700', message: 'Generic Thirdparty consent error' },
-    THIRDPARTY_CONSENT_REQUEST_ERROR: { code: '7800', message: 'Generic Thirdparty consent request error' },
-    THIRDPARTY_CREDENTIAL_ERROR:      { code: '7900', message: 'Generic Thirdparty credential error' },
+    THIRDPARTY_ACCOUNT_LINKING_ERROR: { code: '7200', message: 'Generic Thirdparty account linking error' },
+    THIRDPARTY_AUTH_SERVICE_ERROR:    { code: '7300', message: 'Generic Thirdparty auth service error' },
 };
 
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "15.4.2",
+  "version": "15.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "15.4.2",
+  "version": "15.5.0",
   "description": "A set of standard components for connecting to Mojaloop API enabled Switches",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Thoughts? Too granular? 

Maybe fewer and based on the bigger-picture workflows since some of those errors are children to a flow? (compared to what I have in the commit)

I believe this is the only place I need to put these :thinking: ?
```
    THIRDPARTY_ERROR:                 { code: '7000', message: 'Generic Thirdparty error' },
    THIRDPARTY_TRANSACTION_ERROR:     { code: '7100', message: 'Generic Thirdparty transaction error' },
    THIRDPARTY_ACCOUNT_LINKING_ERROR: { code: '7200', message: 'Generic Thirdparty account linking error' },
```
gradually expanded like so
 |
v

```
    THIRDPARTY_ERROR:                 { code: '7000', message: 'Generic thirdparty error' },
    THIRDPARTY_TRANSACTION_ERROR:     { code: '7100', message: 'Generic thirdparty transaction error' },
    THIRDPARTY_AUTHENTICATION_FAILED: { code: '7101', message: 'Authentication failed for thirdparty transaction' },
    THIRDPARTY_ACCOUNT_LINKING_ERROR: { code: '7200', message: 'Generic Thirdparty account linking error' },
    THIRDPARTY_OTP_INVALID:           { code: '7201', message: 'Invalid OTP for account linking' },
```