### PR TITLE
fix querystring type to be string->any dictionary rather than string.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -561,7 +561,7 @@ declare namespace SDKStandardComponents {
         method: RequestMethod
         uri: string
         agent: http.Agent
-        qs?: string
+        qs?: { [key: string]: any }
         headers?: Record<string, string>
         // body is passed to http.ClientRequest.write
         // https://nodejs.org/api/http.html#http_class_http_clientrequest

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -561,7 +561,7 @@ declare namespace SDKStandardComponents {
         method: RequestMethod
         uri: string
         agent: http.Agent
-        qs?: { [key: string]: any }
+        qs?: { [key: string]: unknown }
         headers?: Record<string, string>
         // body is passed to http.ClientRequest.write
         // https://nodejs.org/api/http.html#http_class_http_clientrequest

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "15.5.0",
+  "version": "15.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "15.5.0",
+  "version": "15.5.1",
   "description": "A set of standard components for connecting to Mojaloop API enabled Switches",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "15.6.0",
+  "version": "15.6.1",
   "description": "A set of standard components for connecting to Mojaloop API enabled Switches",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Note that the querystring module expects an object with dict type semantics rather than a plain string.

see: https://nodejs.org/api/querystring.html#querystring_querystring_stringify_obj_sep_eq_options
and: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/querystring.d.ts#L20
and: https://github.com/mojaloop/sdk-standard-components/blob/master/src/lib/request.js#L32