### PR TITLE
feature: add PATCH /transfers/{transferId} request to mojaloopRequests module

### DIFF
--- a/src/lib/requests/mojaloopRequests.js
+++ b/src/lib/requests/mojaloopRequests.js
@@ -165,6 +165,15 @@ class MojaloopRequests extends BaseRequests {
     }
 
     /**
+     * Executes a PATCH /transfers/{ID} request for the specified transfer update
+     *
+     * @returns {object} - JSON response body if one was received
+     */
+    async patchTransfers(transferId, body, destFspId) {
+        return this._patch(`transfers/${transferId}`, 'transfers', body, destFspId);
+    }
+
+    /**
      * Executes a PUT /transfers/{ID}/error request for the specified error
      *
      * @returns {object} - JSON response body if one was received

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "15.10.5",
+  "version": "15.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "15.10.5",
+  "version": "15.11.0",
   "description": "A set of standard components for connecting to Mojaloop API enabled Switches",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Adding capability to send a PATCH /transfers/{transferId} request from mojaloopRequests module. This enables implementation of the "final notification" message as per mojaloop API v1.1.