### PR TITLE
chore: added .npmignore so that the test folder is not included when publishing packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# Ignore tests for publishing
+test/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@mojaloop/api-snippets": "^14.0.0",
         "@types/jest": "^28.1.4",
-        "@types/node": "^18.0.1",
+        "@types/node": "^18.0.3",
         "eslint": "^8.19.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
@@ -26,7 +26,7 @@
         "jest-junit": "^14.0.0",
         "nock": "^13.2.8",
         "npm-audit-resolver": "3.0.0-7",
-        "npm-check-updates": "^15.0.2",
+        "npm-check-updates": "^15.2.6",
         "pre-commit": "^1.2.2",
         "replace": "^1.2.1",
         "standard-version": "^9.5.0",
@@ -1943,9 +1943,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.1.tgz",
-      "integrity": "sha512-CmR8+Tsy95hhwtZBKJBs0/FFq4XX7sDZHlGGf+0q+BRZfMbOTkzkj0AFAuTyXbObDIoanaBBW0+KEW+m3N16Wg==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
+      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -3011,12 +3011,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
       "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
-      "dev": true
-    },
-    "node_modules/cint": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/cint/-/cint-8.2.1.tgz",
-      "integrity": "sha1-cDhrG0jidz0NYxZqVa/5TvRFahI=",
       "dev": true
     },
     "node_modules/cjs-module-lexer": {
@@ -9026,13 +9020,12 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-15.0.2.tgz",
-      "integrity": "sha512-ZSmNUm2Cl8K7VZBhLY4/AE2NHmZfR4glKoRZIeJrgg5bvFP1LhRBU3tdS+IX1+MLoUvpF2L+Q7oD5QO+nBOm+Q==",
+      "version": "15.2.6",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-15.2.6.tgz",
+      "integrity": "sha512-lXihP+6EjHW74ENE6YYW2feUmdsfK4evus2ZTCyTd0QSnmHdx0bcHpiHsjgqjPtIqgHPJXLCrV6gd3JGYZg3xg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
-        "cint": "^8.2.1",
         "cli-table": "^0.3.11",
         "commander": "^9.3.0",
         "fast-memoize": "^2.5.2",
@@ -9049,7 +9042,7 @@
         "pacote": "^13.6.1",
         "parse-github-url": "^1.0.2",
         "progress": "^2.0.3",
-        "prompts-ncu": "^2.5.0",
+        "prompts-ncu": "^2.5.1",
         "rc-config-loader": "^4.1.0",
         "remote-git-tags": "^3.0.0",
         "rimraf": "^3.0.2",
@@ -10141,9 +10134,9 @@
       }
     },
     "node_modules/prompts-ncu": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-2.5.0.tgz",
-      "integrity": "sha512-a9WdInrG7zSlmfzDszmF3r8O4grZRI8+ChV0LtagHRT4dH7F+kxkrwFPGxeS83FZgAGBx3AXoLP+c4kGJb1P3w==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-2.5.1.tgz",
+      "integrity": "sha512-Hdd7GgV7b76Yh9FP9HL1D9xqtJCJdVPpiM2vDtuoc8W1KfweJe15gutFYmxkq83ViFaagFM8K0UcPCQ/tZq8bA==",
       "dev": true,
       "dependencies": {
         "kleur": "^4.0.1",
@@ -14125,9 +14118,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.1.tgz",
-      "integrity": "sha512-CmR8+Tsy95hhwtZBKJBs0/FFq4XX7sDZHlGGf+0q+BRZfMbOTkzkj0AFAuTyXbObDIoanaBBW0+KEW+m3N16Wg==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
+      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -14926,12 +14919,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
       "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
-      "dev": true
-    },
-    "cint": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/cint/-/cint-8.2.1.tgz",
-      "integrity": "sha1-cDhrG0jidz0NYxZqVa/5TvRFahI=",
       "dev": true
     },
     "cjs-module-lexer": {
@@ -19535,13 +19522,12 @@
       }
     },
     "npm-check-updates": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-15.0.2.tgz",
-      "integrity": "sha512-ZSmNUm2Cl8K7VZBhLY4/AE2NHmZfR4glKoRZIeJrgg5bvFP1LhRBU3tdS+IX1+MLoUvpF2L+Q7oD5QO+nBOm+Q==",
+      "version": "15.2.6",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-15.2.6.tgz",
+      "integrity": "sha512-lXihP+6EjHW74ENE6YYW2feUmdsfK4evus2ZTCyTd0QSnmHdx0bcHpiHsjgqjPtIqgHPJXLCrV6gd3JGYZg3xg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
-        "cint": "^8.2.1",
         "cli-table": "^0.3.11",
         "commander": "^9.3.0",
         "fast-memoize": "^2.5.2",
@@ -19558,7 +19544,7 @@
         "pacote": "^13.6.1",
         "parse-github-url": "^1.0.2",
         "progress": "^2.0.3",
-        "prompts-ncu": "^2.5.0",
+        "prompts-ncu": "^2.5.1",
         "rc-config-loader": "^4.1.0",
         "remote-git-tags": "^3.0.0",
         "rimraf": "^3.0.2",
@@ -20378,9 +20364,9 @@
       }
     },
     "prompts-ncu": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-2.5.0.tgz",
-      "integrity": "sha512-a9WdInrG7zSlmfzDszmF3r8O4grZRI8+ChV0LtagHRT4dH7F+kxkrwFPGxeS83FZgAGBx3AXoLP+c4kGJb1P3w==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-2.5.1.tgz",
+      "integrity": "sha512-Hdd7GgV7b76Yh9FP9HL1D9xqtJCJdVPpiM2vDtuoc8W1KfweJe15gutFYmxkq83ViFaagFM8K0UcPCQ/tZq8bA==",
       "dev": true,
       "requires": {
         "kleur": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@mojaloop/api-snippets": "^14.0.0",
     "@types/jest": "^28.1.4",
-    "@types/node": "^18.0.1",
+    "@types/node": "^18.0.3",
     "eslint": "^8.19.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-import": "2.26.0",
@@ -57,7 +57,7 @@
     "jest-junit": "^14.0.0",
     "nock": "^13.2.8",
     "npm-audit-resolver": "3.0.0-7",
-    "npm-check-updates": "^15.0.2",
+    "npm-check-updates": "^15.2.6",
     "pre-commit": "^1.2.2",
     "replace": "^1.2.1",
     "standard-version": "^9.5.0",


### PR DESCRIPTION
This is to fix Image Scans picking up unnecessary `test/data` folder in the Unit/Integration tests which contain dummy keys, ref: https://app.circleci.com/pipelines/github/mojaloop/simulator/215/workflows/56f815aa-b521-4a20-b43e-ee8edc9cb6da/jobs/1862