### PR TITLE
feat: enable elliptic curve es256 for JWS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "18.2.0",
+  "version": "18.3.0-snapshot.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mojaloop/sdk-standard-components",
-      "version": "18.2.0",
+      "version": "18.3.0-snapshot.0",
       "license": "Apache-2.0",
       "dependencies": {
         "base64url": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2566,12 +2566,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4742,9 +4742,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@mojaloop/api-snippets": "^17.5.1",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.9",
-        "audit-ci": "^7.0.1",
+        "audit-ci": "^7.1.0",
         "eslint": "8.57.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.29.1",
@@ -30,7 +30,7 @@
         "pre-commit": "^1.2.2",
         "replace": "^1.2.2",
         "standard-version": "^9.5.0",
-        "typescript": "^5.5.2"
+        "typescript": "^5.5.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2273,9 +2273,9 @@
       "dev": true
     },
     "node_modules/audit-ci": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.0.1.tgz",
-      "integrity": "sha512-NAZuQYyZHmtrNGpS4qfUp8nFvB+6UdfSOg7NUcsyvuDVfulXH3lpnN2PcXOUj7Jr3epAoQ6BCpXmjMODC8SBgQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -11602,9 +11602,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "18.2.0",
+  "version": "18.3.0-snapshot.0",
   "description": "A set of standard components for connecting to Mojaloop API enabled Switches",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@mojaloop/api-snippets": "^17.5.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.9",
-    "audit-ci": "^7.0.1",
+    "audit-ci": "^7.1.0",
     "eslint": "8.57.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-import": "2.29.1",
@@ -61,7 +61,7 @@
     "pre-commit": "^1.2.2",
     "replace": "^1.2.2",
     "standard-version": "^9.5.0",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.3"
   },
   "standard-version": {
     "scripts": {

--- a/src/lib/jws/jwsValidator.js
+++ b/src/lib/jws/jwsValidator.js
@@ -15,8 +15,7 @@ const jwt = require('jsonwebtoken');
 const safeStringify = require('fast-safe-stringify');
 
 // the JWS signature algorithm to use. Note that Mojaloop spec requires RS256 at present
-const SIGNATURE_ALGORITHM = 'RS256';
-
+const SIGNATURE_ALGORITHMS = ['RS256', 'ES256'];
 
 /**
  * Provides methods for Mojaloop compliant JWS signing and signature verification
@@ -73,7 +72,7 @@ class JwsValidator {
             // validate signature
             const result = jwt.verify(token, pubKey, {
                 complete: true,
-                algorithms: [ SIGNATURE_ALGORITHM ]  //only allow our SIGNATURE_ALGORITHM
+                algorithms: SIGNATURE_ALGORITHMS  //only allow our SIGNATURE_ALGORITHM
             });
 
             // check protected header has all required fields and matches actual incoming headers
@@ -101,8 +100,8 @@ class JwsValidator {
         if(!decodedProtectedHeader['alg']) {
             throw new Error(`Decoded protected header does not contain required alg element: ${safeStringify(decodedProtectedHeader)}`);
         }
-        if(decodedProtectedHeader.alg !== SIGNATURE_ALGORITHM) {
-            throw new Error(`Invalid protected header alg '${decodedProtectedHeader.alg}' should be '${SIGNATURE_ALGORITHM}'`);
+        if(!SIGNATURE_ALGORITHMS.includes(decodedProtectedHeader.alg)) {
+            throw new Error(`Invalid protected header alg '${decodedProtectedHeader.alg}' should be '${SIGNATURE_ALGORITHMS.join(' or ')}'`);
         }
 
         // check FSPIOP-URI is present and matches

--- a/test/unit/jws.perf.test.js
+++ b/test/unit/jws.perf.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const fs = require('fs');
+const JwsTest = require('../../src/lib/jws');
+const Signer = JwsTest.signer;
+const Validator = JwsTest.validator;
+const mockLogger = require('../__mocks__/mockLogger');
+const crypto = require('crypto');
+
+const signingKey = fs.readFileSync(__dirname + '/data/jwsSigningKey.pem');
+const validationKey = fs.readFileSync(__dirname + '/data/jwsValidationKey.pem');
+const key = {
+    'kty': 'EC',
+    'd': 'iYjERsNErBjCQljkeU8EJVAwU-dMxi_07vdYgTPRsx4',
+    'use': 'sig',
+    'crv': 'P-256',
+    'x': 'ok3_fYYnzhXij__aLGXKr0AKGjjUo1tAqt9z4jp3iog',
+    'y': '_AlRjdUsqPTbpRExkd5vNcsqCSKSDx31mBuMewZTcds',
+    'alg': 'ES256'
+};
+
+const signingKeyEC = crypto.createPrivateKey({format: 'jwk', key}).export({format: 'pem', type: 'sec1'});
+const validationKeyEC = crypto.createPublicKey({format: 'jwk', key}).export({format: 'pem', type: 'spki'});
+
+describe('JWS', () => {
+    let signer;
+    let signerEC;
+    let testOpts;
+    // let testOptsData;
+    let body;
+
+    beforeEach(() => {
+        signer = new Signer({
+            signingKey: signingKey,
+            logger: mockLogger({ app: 'jws-test' }, undefined)
+        });
+        signerEC = new Signer({
+            signingKey: signingKeyEC,
+            logger: mockLogger({ app: 'jws-test' }, undefined)
+        });
+        body = { test: 123 };
+        // An request-promise-native style request uses the `.uri` and `.body` properties instead of the `.url` and `.data` properties.
+        testOpts = {
+            headers: {
+                'fspiop-source': 'mojaloop-sdk',
+                'fspiop-destination': 'some-other-fsp',
+                'date': new Date().toISOString(),
+            },
+            method: 'PUT',
+            uri: 'https://someswitch.com:443/prefix/parties/MSISDN/12345678',
+            body,
+        };
+    });
+
+    function testValidateSignedRequest(shouldFail, key) {
+        const request = {
+            headers: testOpts.headers,
+            body: body,
+        };
+
+        const validate = () => {
+            const validator = new Validator({
+                validationKeys: {
+                    'mojaloop-sdk': key
+                },
+                logger: mockLogger({ app: 'validate-test' }, undefined)
+            });
+            validator.validate(request);
+        };
+
+        if (shouldFail) {
+            expect(validate).toThrow();
+        } else {
+            validate();
+        }
+    }
+
+    test('Should generate valid JWS headers and signature for request with body', () => {
+        for (let i = 1; i < 1000; i++) signer.sign(testOpts);
+
+        expect(testOpts.headers['fspiop-signature']).toBeTruthy();
+        expect(testOpts.headers['fspiop-uri']).toBe('/parties/MSISDN/12345678');
+        expect(testOpts.headers['fspiop-http-method']).toBe('PUT');
+
+        testValidateSignedRequest(false, validationKey);
+    });
+
+    test('Should generate valid JWS headers and signature for request with body ES256', () => {
+        for (let i = 1; i < 1000; i++) signerEC.sign(testOpts, 'ES256');
+
+        expect(testOpts.headers['fspiop-signature']).toBeTruthy();
+        expect(testOpts.headers['fspiop-uri']).toBe('/parties/MSISDN/12345678');
+        expect(testOpts.headers['fspiop-http-method']).toBe('PUT');
+
+        testValidateSignedRequest(false, validationKeyEC);
+    });
+});


### PR DESCRIPTION
Closes #203 
- During signing the algorithm is determined based on the contents of the key file
- During verification both RS256 and ES256 are allowed.
- Added a performance test to illustrate the impact.
  The result is available [here](https://app.circleci.com/pipelines/github/mojaloop/sdk-standard-components/931/workflows/8f5977c2-5d82-4ce6-b9bc-3964c19ddc72/jobs/3972?invite=true#step-107-11001_33) and shows much better performance when using ES256:
  ![image](https://github.com/mojaloop/sdk-standard-components/assets/3054299/f4fb840d-6e88-4f74-a677-27aff090ec5f)
