### PR TITLE
fix: javascript's floating point issue with amount

### DIFF
--- a/src/lib/ilp/IlpBase.js
+++ b/src/lib/ilp/IlpBase.js
@@ -124,7 +124,7 @@ class IlpBase {
         }
 
         const decimalPlaces = currencyDecimals[currency];
-        return `${Number(amount) * Math.pow(10, decimalPlaces)}`;
+        return `${(Number(amount) * Math.pow(10, decimalPlaces)).toFixed(decimalPlaces)}`;
     }
 
     /**


### PR DESCRIPTION
```
const amount = 60.1234;
const decimalPlaces = 2;
console.log(`${Number(amount) * Math.pow(10, decimalPlaces)}`);
```
returns `"6012.339999999999"`

So this is a fix to prevent it from happening
