### PR TITLE
chore: add context org-global to CircleCI setup workflow (#4044)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
     setup:
         jobs:
             - build/workflow:
+                  context: org-global
                   filters:
                       tags:
                           only: /v\d+(\.\d+){2}(-[a-zA-Z-][0-9a-zA-Z-]*\.\d+)?/


### PR DESCRIPTION
## Summary
- Adds `context: org-global` to the `build/workflow` setup job in `.circleci/config.yml`
- This was the only repo among the four affected repos missing this context
- Without it, CI env vars like `GITHUB_TOKEN` are not available during the dynamic config parameter generation phase, causing the `github_release` job to fail silently

## Context
The `mojaloop/build` CircleCI orb uses dynamic configuration (`setup: true`). The setup workflow generates the actual build/test/release workflow. Without `context: org-global` on the setup job, environment variables from the org-global context (including `GITHUB_TOKEN` needed for `gh release create`) are not available.

The other three repos (`central-services-error-handling`, `central-services-health`, `sdk-scheme-adapter`) already have `context: org-global` set.

Refs: https://github.com/mojaloop/project/issues/4044

## Test plan
- [ ] Verify CircleCI pipeline runs successfully on this branch
- [ ] After merge, push a release tag and confirm the `GitHub release` job runs and creates a GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)